### PR TITLE
migrate to OpenFeature 1.6+ and enable lifecycle support in CloudBees Provider

### DIFF
--- a/src/CloudBees.OpenFeature.Provider/CloudBees.OpenFeature.Provider.csproj
+++ b/src/CloudBees.OpenFeature.Provider/CloudBees.OpenFeature.Provider.csproj
@@ -5,8 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenFeature" Version="[1.0.1, 2.0.0)" />
-    <PackageReference Include="rox-server" Version="5.1.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
+    <PackageReference Include="OpenFeature" Version="[1.6.0, 2.0.0)" />
+    <PackageReference Include="rox-server" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**what is change? -**
This PR upgrades the CloudBees OpenFeature Provider to support OpenFeature 1.6.0 and above, aligning with the official provider lifecycle specification (Initialize, Shutdown, GetStatus). It also simplifies setup and streamlining provider initialization.

**Why this change?**
Previously, our provider was defined to support OpenFeature [1.0.1, 2.0.0), but it wasn’t actually compatible with versions above 1.5.x due to:

Lack of support for the async Initialize lifecycle method introduced in OpenFeature 1.6+
Use of SetProvider() instead of the now-preferred SetProviderAsync()
Missing status tracking via ProviderStatus
This led to silent failures or unexpected behaviors during integration with SDK v1.6+ apps.

**Why target [1.6.0, 2.0.0)?**

The provider now relies on APIs introduced in OpenFeature 1.6.0, making earlier versions incompatible. This change avoids version conflicts, improves stability, and ensures compatibility with current OpenFeature best practices.



ref(sample app):
![Screenshot 2025-04-04 at 1 43 26 PM](https://github.com/user-attachments/assets/6a18aec6-b699-4d78-ab52-e3598801abb7)

